### PR TITLE
Fixed Firebase Delete Function

### DIFF
--- a/functions/callableFunctions/indexing/create.js
+++ b/functions/callableFunctions/indexing/create.js
@@ -18,7 +18,7 @@ exports.indexItems = functions.firestore
     .document("menuitems/{itemId}")
     .onCreate((snap, context) => {
         const item = {
-            objectID: context.params.itemId,
+            objectID: snap.id,
             title: snap.data().title,
             description: snap.data().description,
             associatedTruck: snap.data().associatedTruck,

--- a/functions/callableFunctions/indexing/delete.js
+++ b/functions/callableFunctions/indexing/delete.js
@@ -17,6 +17,6 @@ const index = client.initIndex(ALGOLIA_INDEX_NAME);
 exports.removeItemFromIndex = functions.firestore
     .document("menuitems/{itemId}")
     .onDelete((snap, context) => {
-        const itemId = context.params.itemId;
+        const itemId = snap.id;
         return index.deleteObject(itemId);
     });

--- a/src/pages/search-page/index.jsx
+++ b/src/pages/search-page/index.jsx
@@ -1,11 +1,14 @@
 //import CombinedMenuItems from "../../components/CombinedMenuItems";
 import Search from "../../components/Search";
-
+import TruckLocations from "../../components/TruckLocations";
 
 export const Searchpage = () => {
     return (
         <>
             <Search></Search>
+            <div height={100}></div>
+            <h2>Times/Locations</h2>
+            <TruckLocations></TruckLocations>
             {/*<CombinedMenuItems assocTruck={"None"}></CombinedMenuItems>*/}
         </>
     );


### PR DESCRIPTION
Fixed Firebase Function that deletes a record from the Algolia index when the corresponding document is deleted from the Firestore Database. Also updated Firebase Function ran when an item is created to help with the delete functionality.

* Added truck locations/times to search page for trouble shooting.